### PR TITLE
2.1.4小节 → 创建第二个Activity → 向导小改变

### DIFF
--- a/basics/firstapp/starting-activity.html
+++ b/basics/firstapp/starting-activity.html
@@ -3379,7 +3379,7 @@ intent.putExtra(EXTRA_MESSAGE, message);
 </li>
 <li><p>在弹出窗口打开安卓文件夹，选择安卓活动然后点击<strong>下一步</strong>。</p>
 </li>
-<li><p>选择<strong>BlankActivity</strong>，然后点击<strong>下一步</strong></p>
+<li><p>选择<strong>Blank Activity with Fragment</strong>，然后点击<strong>下一步</strong></p>
 </li>
 <li><p>填写Activity详细信息：</p>
 <ul>


### PR DESCRIPTION
在最新版本的Eclipse（ADT包为adt-bundle-windows-x86_64-20140702.zip）中，创建新的Activity的时候，如果要带Fragment的，向导选项应该是“Blank Activity with Fragment”。注意到官方教程也有错误，但不知道往哪提，所以先提交到这吧。
