### PR TITLE
修正<>里面内容不可见的问题

### DIFF
--- a/basics/firstapp/building-ui.md
+++ b/basics/firstapp/building-ui.md
@@ -22,13 +22,13 @@ Layouts是ViewGroup的子类，接下来的练习将使用[LinearLayout](http://
 
 1 在Android Studio中，从res/layout目录打开activity_my.xml文件。上一节创建新项目时生成的BlankActivity，包含一个activity_my.xml文件，该文件根元素是一个包含TextView的RelativeLayout。
 
-2 在**Preview**面板点击![image](as-hide-side.png)关闭右侧Preview面板，在Android Studio中，当打开布局文件的时，可以看到一个Preview面板，点击这个面板中的标签，可利用WYSIWYG（所见即所得）工具在Design面板看到对应的图形化效果，但在本节直接操作XML文件即可。
+2 在**Preview**面板点击![image](as-hide-side.png)关闭右侧Preview面板，在Android Studio中，当打开布局文件时，可以看到一个Preview面板，点击这个面板中的标签，可利用WYSIWYG（所见即所得）工具在Design面板看到对应的图形化效果，但在本节直接操作XML文件即可。
 
 3 删除 TextView 标签.
 
 4 把 RelativeLayout 标签改为 LinearLayout.
 
-5 为<LinearLayout>添加 android:orientation 属性并设置值为 "horizontal".
+5 为< LinearLayout >添加 android:orientation 属性并设置值为 "horizontal".
 
 6 去掉android:padding 属性和tools:context 属性.
 
@@ -58,7 +58,7 @@ res/layout/activity_my.xml
 
 与其它View一样，我们需要设置XML里的某些属性来指定EditText的属性值，以下是应该在线性布局里指定的一些属性元素：
 
-1 在activity\_my.xml文件的 <LinearLayout\> 标签内定义一个 <EditText\> 标签，并设置id属性为@+id/edit_message.
+1 在activity\_my.xml文件的 < LinearLayout > 标签内定义一个 < EditText > 标签，并设置id属性为@+id/edit_message.
 
 2 设置layout_width和layout_height属性为 wrap_content.
 
@@ -131,7 +131,7 @@ res/layout/activity_my.xml
 
 1 在 Android Studio里, 编辑 res/layout下的 activity_my.xml 文件.
 
-2 在LinearLayout 内部, 在<EditText\>标签之后定义一个<Button\>标签.
+2 在LinearLayout 内部, 在< EditText >标签之后定义一个< Button >标签.
 
 3 设置Button的width 和 height 属性值为 "wrap_content" 以便让Button大小能完整显示其上的文本.
 


### PR DESCRIPTION
<>里面内容不可见，如：<LinearLayout>（内容在尖括号里），文中有几个地方出现此问题影响阅读。
若要<>里面的内容可见，需在<>里面的内容前后加上空格， 如：< LinearLayout >。